### PR TITLE
Fix admin loading and user navigation issues

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -1307,7 +1307,7 @@ def api_user_candidates(user_id: int, limit: int = Query(5, ge=1, le=50)):
     with get_conn() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
         cur.execute("SELECT role FROM users WHERE id=%s", (user_id,))
         row = cur.fetchone()
-        role = (row[0] if row else None)
+        role = (row.get('role') if row else None)
         if role == 'student':
             cur.execute(
                 '''


### PR DESCRIPTION
## Summary
- allow the bot to load admins.txt from multiple possible locations so admin privileges work in Docker
- adjust the back button handler to reopen the role menu for students and supervisors while keeping admin behaviour
- fix /api/user-candidates to read the role column correctly with a RealDict cursor

## Testing
- python -m compileall bot/bot.py server/main.py

------
https://chatgpt.com/codex/tasks/task_e_68cc2cc35ce8832c800574ebcc34e66c