### PR TITLE
Allow topic creation for bound users and track confirmations

### DIFF
--- a/01_schema.sql
+++ b/01_schema.sql
@@ -14,6 +14,7 @@ CREATE TABLE users (
   full_name       TEXT NOT NULL,
   email           TEXT,
   username        TEXT,
+  is_confirmed    BOOLEAN NOT NULL DEFAULT FALSE,
   role            VARCHAR(20) NOT NULL, -- 'student' | 'supervisor' | 'admin'
   embeddings      TEXT,
   consent_personal BOOLEAN,

--- a/schema.md
+++ b/schema.md
@@ -10,6 +10,7 @@
 - full_name: text, NOT NULL
 - email: text
 - username: text — Telegram (полная ссылка вида https://t.me/<username>)
+- is_confirmed: boolean — подтверждён ли пользователь в Telegram
 - role: varchar(20), NOT NULL — 'student' | 'supervisor' | 'admin'
 - embeddings: text
 - consent_personal: boolean — согласие на обработку персональных данных


### PR DESCRIPTION
## Summary
- add an `is_confirmed` flag to users and mark it when a profile self-registers or binds a Telegram account
- expose confirmation data via `/api/whoami` so the bot can reuse previous choices instead of asking on every `/start`
- create topics from the bot on behalf of the current user and surface the result (including duplicates) in the reply

## Testing
- python -m compileall bot server

------
https://chatgpt.com/codex/tasks/task_e_68cc783690b8832cb0fa2851ebb218fe