### PR TITLE
Add admin actions for match recommendations

### DIFF
--- a/templates/view_role.html
+++ b/templates/view_role.html
@@ -10,14 +10,21 @@
     dt { font-weight: 600; }
     dd { margin: 0 0 8px 0; }
     .actions { margin: 12px 0; }
+    .muted { color:#64748b; }
     a.btn, button { background: #2563eb; color: white; border: 0; padding: 10px 14px; border-radius: 8px; cursor: pointer; text-decoration:none; }
     a.btn.secondary { background: #334155; }
     table { width:100%; border-collapse: collapse; }
-    th, td { border-bottom:1px solid #e2e8f0; padding:6px; text-align:left; }
+    th, td { border-bottom:1px solid #e2e8f0; padding:6px; text-align:left; vertical-align: top; }
+    .msg { margin: 12px 0; padding: 10px 12px; border-radius: 8px; background: #ecfeff; border: 1px solid #38bdf8; }
+    details summary { cursor: pointer; color: #2563eb; margin-bottom: 6px; }
+    form.stacked-form { display: flex; flex-direction: column; gap: 6px; }
+    form.stacked-form textarea { width: 100%; min-height: 70px; padding: 8px; border: 1px solid #cbd5e1; border-radius: 8px; font-family: inherit; }
+    form.stacked-form button { align-self: flex-start; }
   </style>
   </head>
 <body>
   <h2>Роль #{{ role.id }} — {{ role.name }}</h2>
+  {% if msg %}<div class='msg'>{{ msg }}</div>{% endif %}
   <div class='actions'>
     <a class='btn secondary' href='/topic/{{ role.topic_id }}'>Назад к теме</a>
   </div>
@@ -41,17 +48,35 @@
     </dl>
   </div>
 
-  <div class='card' style='margin-top:12px;'>
+  <div class='card' id='role-candidates' style='margin-top:12px;'>
     <h3>Кандидаты (топ-10)</h3>
     {% if candidates %}
       <table>
-        <tr><th>Место</th><th>Студент</th><th>Username</th><th>Оценка</th></tr>
+        <tr><th>Место</th><th>Студент</th><th>Username</th><th>Оценка</th><th>Действия</th></tr>
         {% for c in candidates %}
           <tr>
             <td>{{ c.rank or '-' }}</td>
             <td><a href='/user/{{ c.user_id }}'>{{ c.full_name }}</a></td>
             <td>{{ c.username or '-' }}</td>
             <td>{{ '%.2f'|format(c.score) if c.score is not none else '-' }}</td>
+            <td>
+              {% if role.author_user_id %}
+                <details>
+                  <summary>Пригласить</summary>
+                  <form method='post' action='/send-request' class='stacked-form'>
+                    <input type='hidden' name='sender_user_id' value='{{ role.author_user_id }}' />
+                    <input type='hidden' name='receiver_user_id' value='{{ c.user_id }}' />
+                    <input type='hidden' name='topic_id' value='{{ role.topic_id }}' />
+                    <input type='hidden' name='role_id' value='{{ role.id }}' />
+                    <input type='hidden' name='return_url' value='{{ request.url.path }}#role-candidates' />
+                    <label>Сообщение<textarea name='body' required>{{ c.default_message }}</textarea></label>
+                    <button type='submit'>Отправить приглашение</button>
+                  </form>
+                </details>
+              {% else %}
+                <span class='muted'>Нет автора для заявки</span>
+              {% endif %}
+            </td>
           </tr>
         {% endfor %}
       </table>

--- a/templates/view_supervisor.html
+++ b/templates/view_supervisor.html
@@ -8,14 +8,23 @@
     body { font-family: system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif; margin: 20px; line-height: 1.4; }
     .card { border: 1px solid #e2e8f0; border-radius: 12px; padding: 16px; max-width: 900px; }
     dt { font-weight: 600; }
+    .muted { color:#64748b; }
     dd { margin: 0 0 8px 0; }
     .actions { margin: 12px 0; }
     a.btn { background: #2563eb; color: white; border: 0; padding: 10px 14px; border-radius: 8px; cursor: pointer; text-decoration:none; }
     a.btn.secondary { background: #334155; }
+    .msg { margin: 12px 0; padding: 10px 12px; border-radius: 8px; background: #ecfeff; border: 1px solid #38bdf8; }
+    table { width: 100%; border-collapse: collapse; margin-top: 10px; }
+    th, td { border-bottom: 1px solid #e2e8f0; padding: 6px; text-align: left; vertical-align: top; }
+    details summary { cursor: pointer; color: #2563eb; margin-bottom: 6px; }
+    form.stacked-form { display: flex; flex-direction: column; gap: 6px; }
+    form.stacked-form textarea { width: 100%; min-height: 70px; padding: 8px; border: 1px solid #cbd5e1; border-radius: 8px; font-family: inherit; }
+    form.stacked-form button { align-self: flex-start; }
   </style>
 </head>
 <body>
   <h2>Профиль руководителя #{{ sup.id }}</h2>
+  {% if msg %}<div class='msg'>{{ msg }}</div>{% endif %}
   <div class='actions'>
     <a class='btn' href='/edit-supervisor/{{ sup.id }}'>Изменить параметры</a>
     <a class='btn secondary' href='/?kind=supervisors'>Назад к списку</a>
@@ -35,6 +44,45 @@
       <dt>Интересы</dt><dd>{{ sup.interests or '-' }}</dd>
       <dt>Требования</dt><dd>{{ sup.requirements or '-' }}</dd>
     </dl>
+  </div>
+
+  <div class='card' id='recommended-topics' style='margin-top:12px;'>
+    <h3>Рекомендованные темы</h3>
+    {% if recommended_topics %}
+      <table>
+        <tr><th>Место</th><th>Тема</th><th>Оценка</th><th>Действия</th></tr>
+        {% for t in recommended_topics %}
+          <tr>
+            <td>{{ t.rank or '-' }}</td>
+            <td>
+              <strong><a href='/topic/{{ t.topic_id }}'>{{ t.title or ('Тема #' ~ t.topic_id) }}</a></strong>
+              <div class='muted'>Автор: {{ t.author_name or '-' }}</div>
+              {% if t.direction %}<div class='muted'>Направление: {{ t.direction }}</div>{% endif %}
+            </td>
+            <td>{{ '%.2f'|format(t.score) if t.score is not none else '-' }}</td>
+            <td>
+              {% if t.author_user_id %}
+                <details>
+                  <summary>Предложить участие</summary>
+                  <form method='post' action='/send-request' class='stacked-form'>
+                    <input type='hidden' name='sender_user_id' value='{{ sup.id }}' />
+                    <input type='hidden' name='receiver_user_id' value='{{ t.author_user_id }}' />
+                    <input type='hidden' name='topic_id' value='{{ t.topic_id }}' />
+                    <input type='hidden' name='return_url' value='{{ request.url.path }}#recommended-topics' />
+                    <label>Сообщение<textarea name='body' required>{{ t.default_message }}</textarea></label>
+                    <button type='submit'>Отправить заявку</button>
+                  </form>
+                </details>
+              {% else %}
+                <span class='muted'>Нет автора для заявки</span>
+              {% endif %}
+            </td>
+          </tr>
+        {% endfor %}
+      </table>
+    {% else %}
+      <p class='muted'>Пока нет сохранённых рекомендаций. Нажмите «Подобрать темы», чтобы обновить список.</p>
+    {% endif %}
   </div>
 </body>
 </html>

--- a/templates/view_topic.html
+++ b/templates/view_topic.html
@@ -8,14 +8,23 @@
     body { font-family: system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif; margin: 20px; line-height: 1.4; }
     .card { border: 1px solid #e2e8f0; border-radius: 12px; padding: 16px; max-width: 900px; }
     dt { font-weight: 600; }
+    .muted { color:#64748b; }
     dd { margin: 0 0 8px 0; }
     .actions { margin: 12px 0; }
     a.btn { background: #2563eb; color: white; border: 0; padding: 10px 14px; border-radius: 8px; cursor: pointer; text-decoration:none; }
     a.btn.secondary { background: #334155; }
+    .msg { margin: 12px 0; padding: 10px 12px; border-radius: 8px; background: #ecfeff; border: 1px solid #38bdf8; }
+    table { width: 100%; border-collapse: collapse; margin-top: 10px; }
+    th, td { border-bottom: 1px solid #e2e8f0; padding: 6px; text-align: left; vertical-align: top; }
+    details summary { cursor: pointer; color: #2563eb; margin-bottom: 6px; }
+    form.stacked-form { display: flex; flex-direction: column; gap: 6px; }
+    form.stacked-form textarea { width: 100%; min-height: 70px; padding: 8px; border: 1px solid #cbd5e1; border-radius: 8px; font-family: inherit; }
+    form.stacked-form button { align-self: flex-start; }
   </style>
 </head>
 <body>
   <h2>Тема #{{ topic.id }}</h2>
+  {% if msg %}<div class='msg'>{{ msg }}</div>{% endif %}
   <div class='actions'>
     <a class='btn' href='/edit-topic/{{ topic.id }}'>Изменить параметры</a>
     <a class='btn secondary' href='/?kind=topics'>Назад к списку</a>
@@ -77,6 +86,46 @@
       <label>Вместимость <input type='number' name='capacity' min='0' placeholder='опционально'></label>
       <button type='submit'>Добавить</button>
     </form>
+  </div>
+
+  <div class='card' id='supervisor-candidates' style='margin-top:12px;'>
+    <h3>Кандидаты в руководители</h3>
+    {% if supervisor_candidates %}
+      <table>
+        <tr><th>Место</th><th>Руководитель</th><th>Оценка</th><th>Действия</th></tr>
+        {% for s in supervisor_candidates %}
+          <tr>
+            <td>{{ s.rank or '-' }}</td>
+            <td>
+              <strong><a href='/supervisor/{{ s.user_id }}'>{{ s.full_name or ('Руководитель #' ~ s.user_id) }}</a></strong>
+              {% if s.username %}<div class='muted'>{{ s.username }}</div>{% endif %}
+              {% if s.position %}<div class='muted'>{{ s.position }}</div>{% endif %}
+              {% if s.capacity %}<div class='muted'>Лимит: {{ s.capacity }}</div>{% endif %}
+            </td>
+            <td>{{ '%.2f'|format(s.score) if s.score is not none else '-' }}</td>
+            <td>
+              {% if topic.author_user_id %}
+                <details>
+                  <summary>Пригласить</summary>
+                  <form method='post' action='/send-request' class='stacked-form'>
+                    <input type='hidden' name='sender_user_id' value='{{ topic.author_user_id }}' />
+                    <input type='hidden' name='receiver_user_id' value='{{ s.user_id }}' />
+                    <input type='hidden' name='topic_id' value='{{ topic.id }}' />
+                    <input type='hidden' name='return_url' value='{{ request.url.path }}#supervisor-candidates' />
+                    <label>Сообщение<textarea name='body' required>{{ s.default_message }}</textarea></label>
+                    <button type='submit'>Отправить приглашение</button>
+                  </form>
+                </details>
+              {% else %}
+                <span class='muted'>Нет автора темы для отправки заявки</span>
+              {% endif %}
+            </td>
+          </tr>
+        {% endfor %}
+      </table>
+    {% else %}
+      <p class='muted'>Пока нет сохранённых рекомендаций. Нажмите «Подобрать руководителей», чтобы обновить список.</p>
+    {% endif %}
   </div>
 </body>
 </html>

--- a/templates/view_user.html
+++ b/templates/view_user.html
@@ -16,10 +16,18 @@
     .actions { margin: 12px 0; }
     button, a.btn { background: #2563eb; color: white; border: 0; padding: 10px 14px; border-radius: 8px; cursor: pointer; text-decoration:none; }
     a.btn.secondary { background: #334155; }
+    .msg { margin: 12px 0; padding: 10px 12px; border-radius: 8px; background: #ecfeff; border: 1px solid #38bdf8; }
+    table { width: 100%; border-collapse: collapse; margin-top: 10px; }
+    th, td { border-bottom: 1px solid #e2e8f0; padding: 6px; text-align: left; vertical-align: top; }
+    details summary { cursor: pointer; color: #2563eb; margin-bottom: 6px; }
+    form.stacked-form { display: flex; flex-direction: column; gap: 6px; }
+    form.stacked-form textarea { width: 100%; min-height: 70px; padding: 8px; border: 1px solid #cbd5e1; border-radius: 8px; font-family: inherit; }
+    form.stacked-form button { align-self: flex-start; }
   </style>
 </head>
 <body>
   <h2>Профиль пользователя #{{ user.id }}</h2>
+  {% if msg %}<div class='msg'>{{ msg }}</div>{% endif %}
   <div class='actions'>
     <a class='btn' href='/edit-user/{{ user.id }}'>Изменить параметры</a>
     <a class='btn secondary' href='/?kind={{ 'supervisors' if user.role=='supervisor' else 'students' }}'>Назад к списку</a>
@@ -92,5 +100,88 @@
       </div>
     </div>
   </div>
+
+  {% if user.role == 'student' %}
+    <div class='card' id='recommended-roles' style='margin-top:12px;'>
+      <h3>Рекомендованные роли</h3>
+      {% if recommended_roles %}
+        <table>
+          <tr><th>Место</th><th>Роль</th><th>Оценка</th><th>Действия</th></tr>
+          {% for r in recommended_roles %}
+            <tr>
+              <td>{{ r.rank or '-' }}</td>
+              <td>
+                <strong><a href='/role/{{ r.role_id }}'>{{ r.role_name or ('Роль #' ~ r.role_id) }}</a></strong>
+                <div class='muted'>Тема: <a href='/topic/{{ r.topic_id }}'>{{ r.topic_title or ('Тема #' ~ r.topic_id) }}</a></div>
+                <div class='muted'>Автор: {{ r.author_name or '-' }}</div>
+              </td>
+              <td>{{ '%.2f'|format(r.score) if r.score is not none else '-' }}</td>
+              <td>
+                {% if r.author_user_id %}
+                  <details>
+                    <summary>Подать заявку</summary>
+                    <form method='post' action='/send-request' class='stacked-form'>
+                      <input type='hidden' name='sender_user_id' value='{{ user.id }}' />
+                      <input type='hidden' name='receiver_user_id' value='{{ r.author_user_id }}' />
+                      <input type='hidden' name='topic_id' value='{{ r.topic_id }}' />
+                      <input type='hidden' name='role_id' value='{{ r.role_id }}' />
+                      <input type='hidden' name='return_url' value='{{ request.url.path }}#recommended-roles' />
+                      <label>Сообщение<textarea name='body' required>{{ r.default_message }}</textarea></label>
+                      <button type='submit'>Отправить заявку</button>
+                    </form>
+                  </details>
+                {% else %}
+                  <span class='muted'>Нет автора для заявки</span>
+                {% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+        </table>
+      {% else %}
+        <p class='muted'>Пока нет сохранённых рекомендаций. Нажмите «Подобрать темы», чтобы обновить список.</p>
+      {% endif %}
+    </div>
+  {% endif %}
+
+  {% if user.role == 'supervisor' %}
+    <div class='card' id='recommended-topics' style='margin-top:12px;'>
+      <h3>Рекомендованные темы</h3>
+      {% if recommended_topics %}
+        <table>
+          <tr><th>Место</th><th>Тема</th><th>Оценка</th><th>Действия</th></tr>
+          {% for t in recommended_topics %}
+            <tr>
+              <td>{{ t.rank or '-' }}</td>
+              <td>
+                <strong><a href='/topic/{{ t.topic_id }}'>{{ t.title or ('Тема #' ~ t.topic_id) }}</a></strong>
+                <div class='muted'>Автор: {{ t.author_name or '-' }}</div>
+                {% if t.direction %}<div class='muted'>Направление: {{ t.direction }}</div>{% endif %}
+              </td>
+              <td>{{ '%.2f'|format(t.score) if t.score is not none else '-' }}</td>
+              <td>
+                {% if t.author_user_id %}
+                  <details>
+                    <summary>Предложить участие</summary>
+                    <form method='post' action='/send-request' class='stacked-form'>
+                      <input type='hidden' name='sender_user_id' value='{{ user.id }}' />
+                      <input type='hidden' name='receiver_user_id' value='{{ t.author_user_id }}' />
+                      <input type='hidden' name='topic_id' value='{{ t.topic_id }}' />
+                      <input type='hidden' name='return_url' value='{{ request.url.path }}#recommended-topics' />
+                      <label>Сообщение<textarea name='body' required>{{ t.default_message }}</textarea></label>
+                      <button type='submit'>Отправить заявку</button>
+                    </form>
+                  </details>
+                {% else %}
+                  <span class='muted'>Нет автора для заявки</span>
+                {% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+        </table>
+      {% else %}
+        <p class='muted'>Пока нет сохранённых рекомендаций. Нажмите «Подобрать темы», чтобы обновить список.</p>
+      {% endif %}
+    </div>
+  {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show recommended roles for students and recommended topics for supervisors with inline request forms in the admin profiles
- surface supervisor candidates on topic pages and add invite controls for student matches on role pages
- add an admin helper endpoint to create application messages and display feedback banners

## Testing
- python -m compileall server

------
https://chatgpt.com/codex/tasks/task_e_68cfd1542f78832ca2254efda993c270