### PR TITLE
Add topic navigation buttons to supervisor matches

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -2305,9 +2305,22 @@ class MentorMatchBot:
             return
         items = res.get('items', [])
         lines = [f'Топ‑5 тем для руководителя #{uid}:']
+        kb: List[List[InlineKeyboardButton]] = []
         for it in items:
-            lines.append(f"#{it.get('rank')}. {it.get('title','–')} — {it.get('reason','')}")
-        kb = [[InlineKeyboardButton('⬅️ К профилю', callback_data=f'supervisor_{uid}')]]
+            title = (it.get('title') or '–').strip() or '–'
+            rank = it.get('rank')
+            reason = (it.get('reason') or '').strip()
+            rank_label = f"#{rank}" if rank else '#?'
+            reason_suffix = f" — {reason}" if reason else ''
+            lines.append(f"{rank_label}. {title}{reason_suffix}")
+            tid = it.get('topic_id')
+            if tid:
+                if title and title != '–':
+                    button_title = f"📄 {title[:40]}"
+                else:
+                    button_title = f"📄 Тема {rank_label}"
+                kb.append([InlineKeyboardButton(self._fix_text(button_title), callback_data=f'topic_{tid}')])
+        kb.append([InlineKeyboardButton('⬅️ К профилю', callback_data=f'supervisor_{uid}')])
         await q.edit_message_text(self._fix_text('\n'.join(lines)), reply_markup=self._mk(kb))
 
     # Back


### PR DESCRIPTION
## Summary
- add inline keyboard buttons to supervisor match results so each recommended topic links to its profile
- keep the text summary while preserving the back-to-profile navigation option

## Testing
- pytest bot/test_bot.py

------
https://chatgpt.com/codex/tasks/task_e_68cfdcf659f8832c8fb6eb7e61433771