### PR TITLE
Require role selection for student applications

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -976,6 +976,43 @@ class MentorMatchBot:
             await q.edit_message_text(self._fix_text('Эта тема ищет другую роль.'))
             return
         title = topic.get('title') or f'#{tid}'
+        if target_role == 'student':
+            roles = await self._api_get(f'/api/topics/{tid}/roles') or []
+            role_choices: List[tuple[int, str]] = []
+            for r in roles:
+                rid = self._parse_positive_int(r.get('id'))
+                if rid is None:
+                    continue
+                name = (r.get('name') or '').strip()
+                label = name or f'Роль #{rid}'
+                role_choices.append((rid, label))
+            if not role_choices:
+                kb = [[InlineKeyboardButton('⬅️ К теме', callback_data=f'topic_{tid}')]]
+                kb.append([InlineKeyboardButton('⬅️ Назад', callback_data='back_to_main')])
+                await q.message.reply_text(
+                    self._fix_text(
+                        'В этой теме пока нет ролей. Попросите автора добавить роли и попробуйте ещё раз.'
+                    ),
+                    reply_markup=self._mk(kb),
+                )
+                return
+            lines = [f'Чтобы подать заявку на тему «{title}», выберите конкретную роль:']
+            if role_choices:
+                lines.append('')
+                lines.append('Доступные роли:')
+                for _, label in role_choices:
+                    lines.append(f'• {label}')
+            kb = [
+                [InlineKeyboardButton(f'📨 {label[:40]}', callback_data=f'apply_role_{rid}')]
+                for rid, label in role_choices
+            ]
+            kb.append([InlineKeyboardButton('⬅️ К теме', callback_data=f'topic_{tid}')])
+            kb.append([InlineKeyboardButton('⬅️ Назад', callback_data='back_to_main')])
+            await q.message.reply_text(
+                self._fix_text('\n'.join(lines)),
+                reply_markup=self._mk(kb),
+            )
+            return
         if target_role == 'supervisor':
             default_body = f'Здравствуйте! Готов(а) стать научным руководителем по теме "{title}".'
             prompt = (

--- a/server/admin.py
+++ b/server/admin.py
@@ -433,6 +433,13 @@ def create_admin_router(get_conn: Callable, templates) -> APIRouter:
             with get_conn() as conn, conn.cursor() as cur:
                 role_id_val = parse_optional_int(role_id)
                 topic_id_int = int(topic_id)
+                cur.execute('SELECT role FROM users WHERE id=%s', (sender_user_id,))
+                sender_row = cur.fetchone()
+                sender_role = (sender_row[0] or '').strip().lower() if sender_row else None
+                if not sender_role:
+                    return _redirect(return_url, 'Не удалось определить роль отправителя заявки')
+                if sender_role == 'student' and role_id_val is None:
+                    return _redirect(return_url, 'Студент должен выбрать конкретную роль для заявки')
                 if role_id_val is not None:
                     cur.execute('SELECT 1 FROM roles WHERE id=%s AND topic_id=%s', (role_id_val, topic_id_int))
                     if not cur.fetchone():


### PR DESCRIPTION
## Summary
- require a role reference when students submit applications through the admin UI or public API
- update the Telegram bot topic application flow so students must pick a specific role before sending a request

## Testing
- python -m compileall server/admin.py server/main.py bot/bot.py

------
https://chatgpt.com/codex/tasks/task_e_68d0237889b8832cb11fc0fb5bf188a6