### PR TITLE
Fix missing role author id in role API response

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -1652,7 +1652,7 @@ def api_get_role(role_id: int):
     with get_conn() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
         cur.execute(
             '''
-            SELECT r.*, t.title AS topic_title, u.full_name AS author
+            SELECT r.*, t.title AS topic_title, t.author_user_id, u.full_name AS author
             FROM roles r
             JOIN topics t ON t.id = r.topic_id
             JOIN users u ON u.id = t.author_user_id


### PR DESCRIPTION
## Summary
- include the topic author id in the `/api/roles/{role_id}` payload so bots can determine the application recipient

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d03b3b5f30832c87430790ff8f8c16